### PR TITLE
EM-36 set up Catch2 testing library with the cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
 ﻿# CMakeList.txt : Top-level CMake project file, do global configuration
 # and include sub-projects here.
 #
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 
 project ("min_span_tree_visualizer")
 
 # Include sub-projects.
 add_subdirectory ("src")
+
+# Configuration for Catch2 
+
+add_subdirectory(lib/Catch2)
+add_executable(tests ${PROJECT_SOURCE_DIR}/tests/test.cpp )
+
+target_link_libraries(tests PRIVATE Catch2::Catch2WithMain) #import not to use Catch2::Catch2 here but rather Catch2WithMain 
+
+include(CTest)
+include(Catch)
+catch_discover_tests(tests)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,10 +3,12 @@
 #
 
 # Add source to this project's executable.
-add_executable (min_span_tree_visualizer "main.cpp" )
+add_executable (min_span_tree_visualizer "main.cpp"   )
+set_property(TARGET min_span_tree_visualizer PROPERTY WIN32_EXECUTABLE FALSE)
 
 if (CMAKE_VERSION VERSION_GREATER 3.12)
   set_property(TARGET min_span_tree_visualizer PROPERTY CXX_STANDARD 20)
 endif()
+
 
 # TODO: Add tests and install targets if needed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,4 +4,4 @@ int main()
 {
 	std::cout << "Hello min span tree visualizer." << std::endl;
 	return 0;
-}
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Add source to this project's executable.
+add_executable (tests "test.cpp" )
+
+if (CMAKE_VERSION VERSION_GREATER 3.12)
+  set_property(TARGET tests PROPERTY CXX_STANDARD 20)
+endif()

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,2 @@
+#include <catch2/catch_test_macros.hpp>
+


### PR DESCRIPTION
Added Catch2 testing library to the cmake project. 

Learnings about Catch2 integration and CMake: 

- largely followed the tutorial [here](https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#top)

Added the following lines of code to the root level CMakeLists.txt: 

# Configuration for Catch2 

```
add_subdirectory(lib/Catch2)
add_executable(tests ${PROJECT_SOURCE_DIR}/tests/test.cpp )

target_link_libraries(tests PRIVATE Catch2::Catch2WithMain) #import not to use Catch2::Catch2 here but rather Catch2WithMain 

include(CTest)
include(Catch)
catch_discover_tests(tests)
```

- Here it was important to use Catch2WithMain and NOT Catch2, as I commented because otherwise I get a linker error: 
`LNK2019 unresolved external symbol main referenced in function "int __cdecl invoke_main(void)" (?invoke_main@@YAHXZ)`

- Important to add a CMakeLists.txt with an `add_executable` under the tests folder. Add a 'test.cpp' file which only needs to contain `#include <catch2/catch_test_macros.hpp>`

Now able to change between running my tests and the application itself, here: 

![image](https://user-images.githubusercontent.com/41984034/218166190-be984a82-9331-4042-b8ea-a4c2db0a2322.png)


