### PR TITLE
:sparkles: implemented threaded time travel playback of solving steps

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,6 +1,8 @@
 #include "app.h"
 #include "draw.h"
 #include <memory>
+#include <thread>
+#include <chrono>
 
 void MyApp::StartUp()
 {
@@ -51,39 +53,147 @@ void MyApp::StartUp()
     for (vector<double> node_data : tinyEWG) {
         auto edgePtr = g->connectNodes(g->getNodeByName(to_string((int)node_data[0])).get(), g->getNodeByName(to_string((int)node_data[1])).get(), node_data[2]);
         auto l = std::make_shared<Line>(Line(*edgePtr));
-        auto linePtr = addLineToDraw(l,d->getLines());
+        auto linePtr = addLineToDraw(l, d->getLines());
         linePtr->setEdgePtr(edgePtr);
         edgePtr->setLinePtr(linePtr);
         auto edgeInversePtr = getInverseEdge(*g, *edgePtr);
         edgeInversePtr->setLinePtr(linePtr); //two edges reference one line on the graph due to bidirectional nature 
     };
+
+    const float spacing = 15;
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(spacing, spacing));
 }
 
+//GUI components are defined here 
 void MyApp::Update()
 {
-    ImGuiWindowFlags flags = ImGuiWindowFlags_NoInputs;
+
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse + ImGuiWindowFlags_NoMove;
+
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(window_width*0.8, window_height));
     ImGui::Begin("Minimum Spanning Tree Visualizer", NULL, flags);
     ImPlot::CreateContext();
     createPlot(*d, window_width, window_height);
+    if (checkPlotClicked(*d)) {
+        d->resetLinesToDefault();
+        current_snapshot = 0; 
+        max_snapshots = 0;
+    };
+    ImPlot::EndPlot();
     ImGui::End();
 
     ImGui::SetNextWindowSize(ImVec2(window_width*0.2, window_height));
     ImGui::SetNextWindowPos(ImVec2(1000, 0), ImGuiCond_FirstUseEver);
-    ImGui::Begin("Controls", NULL);
+    ImGui::Begin("Controls", NULL, flags);
     ImPlot::CreateContext();
-    if (ImGui::Button("Controls")) {
-        auto selectedNode = d->selectedMarker()->getNodePtr();
-        auto MST = prims->findMST(*selectedNode);
-        prims->AddSnapshot(Snapshot(MST)); 
-        std::cout << "found an MST" << std::endl;
-        drawFromSnapshots(prims->getSnapshots(), *d);
+
+    ImGui::RadioButton("Prim's algorithm", &algorithm_choice, 0);
+    ImGui::RadioButton("Kruskal's algorithm", &algorithm_choice, 1); 
+
+    float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+
+    ImGui::PushID(0);
+    ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(0 / 7.0f, 0.6f, 0.6f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0 / 7.0f, 0.7f, 0.7f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0 / 7.0f, 0.8f, 0.8f));
+    if (ImGui::Button("STOP")) { stop_playback = true; };
+    ImGui::PopStyleColor(3);
+    ImGui::PopID();
+
+    ImGui::SameLine(0.0f, spacing);
+
+    ImGui::PushID(1);
+    ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(2 / 7.0f, 0.6f, 0.6f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(2 / 7.0f, 0.7f, 0.7f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(2 / 7.0f, 0.8f, 0.8f));
+    if(ImGui::Button("START"))
+    {
+        thread draw_multiple_thread([this] {this->drawMultipleThread(); });
+        draw_multiple_thread.detach();
+    };
+    ImGui::PopStyleColor(3);
+    ImGui::PopID();
+
+    ImGui::SameLine(0.0f, spacing);
+
+    if (ImGui::ArrowButton("##left", ImGuiDir_Left)) {
+        auto temp = current_snapshot;
+        if (!(temp-- <= 0) && max_snapshots != 0) {
+            current_snapshot--;
+            thread draw_thread([this] {this->drawOnceThread(); });
+            draw_thread.join();
+        }
     }
+    ImGui::SameLine(0.0f, spacing);
+    if (ImGui::ArrowButton("##right", ImGuiDir_Right)) {
+        auto temp = current_snapshot;
+        if (!(temp++ >= max_snapshots-1) && max_snapshots != 0) {
+            current_snapshot++;
+            thread draw_thread([this] {this->drawOnceThread(); });
+            draw_thread.detach();
+        }
+            
+        
+    }
+    if (max_snapshots == 0) {
+        ImGui::Text("Step: - / -", current_snapshot, max_snapshots);
+    }
+    else {
+        ImGui::Text("Step: %d / %d", current_snapshot+1, max_snapshots+1);
+    }
+    
+
+    ImGui::SliderFloat("speed", &selected_playback_speed, 0.0f, 1.0f, "speed = %.2f x");
+
+    if (ImGui::Button("Solve")) {
+        auto selectedNode = d->selectedMarker()->getNodePtr();
+
+        if (algorithm_choice == 0) {
+            prims->clearAll();
+            prims->resetIterationCount();
+            g->resetVisitedState(); 
+            auto MST = prims->findMST(*selectedNode);
+            prims->AddSnapshot(Snapshot(MST));
+            max_snapshots = prims->getSnapshotLength();
+            thread draw_thread([this] {this->drawOnceThread();});
+            draw_thread.detach();
+        }
+        
+        if (algorithm_choice == 1) {
+            //auto MST = kruskals->findMST(*selectedNode);
+            //kruskals->AddSnapshot(Snapshot(MST));
+            //max_snapshots = kruskals->getSnapshotLength();
+        }
+        
+    }
+    float solving_time = 0.245;
+    ImGui::Text("Solving time: %3f ms", solving_time);
     ImGui::End();
 }
 
 void MyApp::OnNotify(Line l)
 {
     //
+}
+
+void MyApp::drawOnceThread()
+{
+    drawFromSnapshots(current_snapshot, prims->getSnapshots(), *d);
+};
+
+void MyApp::drawMultipleThread() {
+    while (current_snapshot != max_snapshots) {
+
+        //If the stop button was pressed, exit the while loop stopping playback 
+        if (stop_playback) {
+            stop_playback = false;
+            break;
+        }
+
+        drawFromSnapshots(current_snapshot, prims->getSnapshots(), *d);
+        current_snapshot++;
+        int time_in_ms = (int)((base_playback_speed_seconds * (1.0/(selected_playback_speed+0.1)))*1000.0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(time_in_ms));
+    }
 }

--- a/src/app.h
+++ b/src/app.h
@@ -4,6 +4,7 @@
 #include "graph.h"
 #include "draw.h"
 #include "prims_algo.h"
+#include <atomic>
 
 class Line;
 
@@ -13,6 +14,14 @@ protected:
     std::unique_ptr<Graph> g = std::make_unique<Graph>();
     std::unique_ptr<Draw> d = std::make_unique<Draw>();
     std::unique_ptr<PrimsAlgorithm> prims = std::make_unique<PrimsAlgorithm>();
+
+    int algorithm_choice = 0;
+    int current_snapshot = 0;
+    int max_snapshots = 0;
+    float base_playback_speed_seconds = 0.1;
+    float selected_playback_speed = 1.0f, max_playback_speed = 1.0f;
+    std::atomic<bool> stop_playback = false; 
+
 public:
     MyApp() = default;
     ~MyApp() = default;
@@ -22,5 +31,10 @@ public:
     //GUI declarations go here
     virtual void Update() final;
     void OnNotify(Line l);
+    void drawOnceThread();
+    void drawMultipleThread();
 
 };
+
+
+

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -117,8 +117,6 @@ void createPlot(Draw &d,int window_width, int window_height) {
     ImPlot::SetupAxesLimits(-100, 100, -100, 100);
     if (d.hasMarkersToDraw()) { drawNodes(d.getMarkers()); };
     if (d.hasLinesToDraw()) { drawLines(d.getLines()); };
-    checkPlotClicked(d);
-    ImPlot::EndPlot();
 }
 
 void drawLines(vector<SharedLinePtr> lines) {
@@ -137,7 +135,7 @@ void drawNodes(vector<SharedMarkerPtr> markers) {
     };
 }
 
-void checkPlotClicked(Draw &d) {
+bool checkPlotClicked(Draw &d) {
 
     if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0)) {
         auto previously_selected = d.selectedMarker();
@@ -166,17 +164,17 @@ void checkPlotClicked(Draw &d) {
             
             
             //else deselect the currently selected marker and select a new one
-            return;
+            return true;
         }
         else {
             //do nothing
-            return;
+            return false;
         }
     }
 }
 
-void drawFromSnapshots(vector<Snapshot> snapshots, Draw& d) {
-    for (auto& snapshot : snapshots) {
+void drawFromSnapshots(int iteration, vector<Snapshot> snapshots, Draw& d) {
+    auto snapshot = snapshots[iteration];
         d.resetLinesToDefault();
         auto pq = snapshot.getPQ();
         while (!pq.empty()) {
@@ -201,5 +199,5 @@ void drawFromSnapshots(vector<Snapshot> snapshots, Draw& d) {
             d.changeLineColour(line, LineColours::RED);
             d.changeLineThickness(line, 6.0);
         }
-   };
+        return;
 }

--- a/src/draw.h
+++ b/src/draw.h
@@ -5,6 +5,7 @@
 #include "marker.h"
 #include "prims_algo.h"
 #include <memory>
+#include <atomic>
 
 class Marker; 
 class Line; 
@@ -34,11 +35,11 @@ public:
 };
 
 void createPlot(Draw &d, int window_width, int window_height);
-void checkPlotClicked(Draw& d);
+bool checkPlotClicked(Draw& d);
 void drawNodes(vector<SharedMarkerPtr>);
 void drawLines(vector<SharedLinePtr>);
 void drawLine(Line);
 void drawMarker(Marker);
 SharedMarkerPtr addMarkerToDraw(SharedMarkerPtr m, vector<SharedMarkerPtr>& markers);
 SharedLinePtr addLineToDraw(SharedLinePtr l,vector<SharedLinePtr>& lines);
-void drawFromSnapshots(vector<Snapshot> s, Draw& d);
+void drawFromSnapshots(int iteration, vector<Snapshot> s, Draw& d);

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -148,4 +148,12 @@ Edge* getInverseEdge(Graph& g, Edge& edge) {
 	return nullptr;
 }
 
+/**
+ * @brief for each node in the node list resets the node back to default as being marked 'unvisited' by some MST algorithm
+ */
+void Graph::resetVisitedState() {
+	for (auto& node : nodeArray) {
+		node->markUnvisited();
+	}
+}
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -29,6 +29,7 @@ public:
 	void removeNode(Node* node_to_remove);
 	pair<float*,float*> getCoordsForPlot();
 	void drawEdge(Edge* e);
+	void resetVisitedState();
 }; 
 
 Edge* getInverseEdge(Graph& g, Edge& edge);

--- a/src/mst_algo.h
+++ b/src/mst_algo.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <queue>
+#include <algorithm>
+#include <utility>
 #include "Edge.h"
 #include "Node.h"
 #include "snapshot.h"
@@ -27,6 +29,22 @@ public:
 	{
 		return solving_snapshots;
 	};
+
+	void clearSnapshots() {
+		solving_snapshots.clear();
+	}
+
+	void clearAll() {
+		solving_snapshots.clear();
+
+		//clear MST_ 
+		std::queue<Edge> empty_MST;
+		std::swap(MST_, empty_MST);
+	}
+
+	int getSnapshotLength() {
+		return solving_snapshots.size();
+	}
 };
 
 void  inline visitNode(Node& node, std::priority_queue<Edge, std::vector<Edge>, std::greater<Edge>>& pq) {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -138,14 +138,21 @@ pair <int, int> Node::getXY() {
  * @brief marks the visited property on a node true 
  */
 void Node::markVisited() {
-	this->visited = true;
+	visited = true;
+}
+
+/**
+ * @brief marks the visited property on a node true
+ */
+void Node::markUnvisited() {
+	visited = false;
 }
 
 /**
  * @brief returns true or false for if the node has been visited 
  */
 bool Node::wasVisited() {
-	return this->visited;
+	return visited;
 }
 
 

--- a/src/node.h
+++ b/src/node.h
@@ -37,6 +37,7 @@ public:
 	Edge* getEdge(Node* fromNode, Node* toNode);
 	std:: pair <int, int> getXY();
 	void markVisited();
+	void markUnvisited();
 	bool wasVisited();
 	friend bool operator==(Node a, Node b);
 	friend std::ostream& operator<<(std::ostream& stream, Node const& n);

--- a/src/prims_algo.h
+++ b/src/prims_algo.h
@@ -5,10 +5,10 @@ class PrimsAlgorithm : public MSTAlgorithm {
 private:
 	std::priority_queue<Edge, std::vector<Edge>, std::greater<Edge>> minPQ_;
 	int iterationCount_ = 0;
-	
 public:
 	PrimsAlgorithm();
 	~PrimsAlgorithm();
 	std::queue<Edge> findMST(Node& startingNode) override;
 	void increaseIteration() { iterationCount_++; }; 
+	void resetIterationCount() { iterationCount_ = 0; };
 };


### PR DESCRIPTION
Implemented threaded time travel playback of solving steps. The user is able to automatically playback the steps, while being able to adjust how fast the playback occurs. They are also able to stop the steps and to press the back and forward buttons to advance or go back one frame at a time. 

![Recording 2023-04-14 at 19 50 48](https://user-images.githubusercontent.com/41984034/232120135-2e7a61b6-5afa-4713-9eb7-7826b4298858.gif)

