### PR TITLE
:lipstick: markers appear above lines

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -121,8 +121,8 @@ void Draw::clearAll() {
 void createPlot(Draw &d,int window_width, int window_height) {
     ImPlot::BeginPlot("Spanning Tree", ImVec2(window_width * 0.8, window_height * 0.95), ImPlotFlags_NoLegend);
     ImPlot::SetupAxesLimits(-100, 100, -100, 100);
-    if (d.hasMarkersToDraw()) { drawNodes(d.getMarkers(),6); };
     if (d.hasLinesToDraw()) { drawLines(d.getLines()); };
+    if (d.hasMarkersToDraw()) { drawNodes(d.getMarkers(),6); };
 }
 
 void drawLines(vector<SharedLinePtr> lines) {


### PR DESCRIPTION
A simple fix. Just needed to swap the order in which the lines and markers are rendered so that lines appear on the bottom. 

![image](https://user-images.githubusercontent.com/41984034/236414791-35effadd-1715-48dd-a7f3-690853459b02.png)
